### PR TITLE
Add Socket.dev supply chain scanning

### DIFF
--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -1,0 +1,23 @@
+name: Socket
+
+on:
+  pull_request:
+    paths:
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '**/pyproject.toml'
+      - '**/requirements*.txt'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '**/pom.xml'
+      - '**/build.gradle*'
+      - '**/gradle.properties'
+
+jobs:
+  socket:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: socketdev/socket-action@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@
 [![Fabric](https://img.shields.io/badge/Fabric-1.20.1-blue?logo=fabric)](build.gradle)
 [![Minecraft](https://img.shields.io/badge/Minecraft-1.20.1-green?logo=minecraft)](https://minecraft.net)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Wolren/PrideLand/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Wolren/PrideLand)
+[![Socket](https://img.shields.io/badge/Socket-Supply%20Chain%20Security-333?logo=socketdotdev)](https://socket.dev)


### PR DESCRIPTION
Adds Socket.dev dependency scanning workflow and badge to protect against supply chain risks (typo-squatting, protestware, abandoned packages, native code risk).